### PR TITLE
fix date on valheim auto update article

### DIFF
--- a/source/_posts/automatic-update-for-valheim-server.md
+++ b/source/_posts/automatic-update-for-valheim-server.md
@@ -1,5 +1,6 @@
 ---
 title: Automatic Update for Valheim Server
+date: 2021-05-21 09:00:00
 tags: 
 - Docker
 - Valheim


### PR DESCRIPTION
The date of publish was missing, causing the article to appear wrong in the order of published blog articles.  